### PR TITLE
fix: performance

### DIFF
--- a/LightBlue/Standalone/StandaloneMetadataStore.cs
+++ b/LightBlue/Standalone/StandaloneMetadataStore.cs
@@ -1,7 +1,7 @@
-using Azure.Storage.Blobs.Models;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace LightBlue.Standalone
 {
@@ -21,9 +21,18 @@ namespace LightBlue.Standalone
 
         public static StandaloneMetadataStore ReadFromStream(FileStream fileStream)
         {
-            using (var reader = new StreamReader(fileStream, System.Text.Encoding.UTF8, true, 1024, true))
+            using (var reader = new StreamReader(fileStream, System.Text.Encoding.UTF8, true, StandaloneAzureBlockBlob.BufferSize, true))
             {
                 var content = reader.ReadToEnd();
+                return JsonSerializer.Deserialize<StandaloneMetadataStore>(content);
+            }
+        }
+
+        public static async Task<StandaloneMetadataStore> ReadFromStreamAsync(FileStream fileStream)
+        {
+            using (var reader = new StreamReader(fileStream, System.Text.Encoding.UTF8, true, StandaloneAzureBlockBlob.BufferSize, true))
+            {
+                var content = await reader.ReadToEndAsync();
                 return JsonSerializer.Deserialize<StandaloneMetadataStore>(content);
             }
         }


### PR DESCRIPTION
- make metadata reading async
- fetching data from FileStream can be pretty slow at scale, even when fetching from it's internal buffer.  By keeping the StreamReader's buffer the same size as the FileStream, it should only need one fetch from the FileStream.